### PR TITLE
Bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,41 @@ The main code can be found in `lib/date_range_formatter.rb` and its behaviour is
 defined in `spec/date_range_formatter_spec.rb`
 
 However, the code is difficult to read and seems to have a bug: when given a
-start date of 2009-11-1 and an end date of 2010-11-3, it should format the
-date range as "1st November 2009 - 3rd November 2010" but actually returns
-"1st - 3rd November 2009".
+start date of `2009-11-1` and an end date of `2010-11-3`, it should format the
+date range as `"1st November 2009 - 3rd November 2010"` but actually returns
+`"1st - 3rd November 2009"`.
 
 Find and fix the bug, writing tests if need be and refactor the code as you
 see fit.
+
+
+# Development
+
+
+### To initialise the project
+
+```bash
+bundle install
+```
+
+
+### To run all tests and rubocop
+
+```bash
+bundle exec rake
+```
+
+
+### To run one file
+
+
+```bash
+bundle exec rspec path/to/test/file.rb
+```
+
+
+### To run one test
+
+```bash
+bundle exec rspec path/to/test/file.rb:TESTLINENUMBER
+```

--- a/spec/date_range_formatter_spec.rb
+++ b/spec/date_range_formatter_spec.rb
@@ -57,6 +57,11 @@ RSpec.describe(DateRangeFormatter) do
         '1st November 2009 - 3rd November 2009 at 10:00'
       )
     end
+
+    it 'formats a date for different year' do
+      formatter = DateRangeFormatter.new('2009-11-1', '2010-11-3')
+      expect(formatter.to_s).to eq('1st November 2009 - 3rd November 2010')
+    end
   end
 
   describe 'for the same year' do


### PR DESCRIPTION
This PR adds a test to document the bug described in the README, in which when given a
start date of `2009-11-1` and an end date of `2010-11-3`, and having to format the
date range as `"1st November 2009 - 3rd November 2010"`, it actually returned
`"1st - 3rd November 2009"`.
